### PR TITLE
🐛 fix: wrap client components with Suspense and force dynamic rendering to resolve useSearchParams error

### DIFF
--- a/src/app/(list)/history/page.tsx
+++ b/src/app/(list)/history/page.tsx
@@ -1,8 +1,13 @@
 import { PokemonHistoryList } from "@/components/pokemon-history-list";
 import { getAllPokemon } from "@/lib/pokemon";
+import { Suspense } from "react";
 
 export default async function History() {
 	const pokemons = await getAllPokemon();
 
-	return <PokemonHistoryList pokemons={pokemons} />;
+	return (
+		<Suspense fallback={<div>Loading...</div>}>
+			<PokemonHistoryList pokemons={pokemons} />
+		</Suspense>
+	);
 }

--- a/src/app/(list)/history/page.tsx
+++ b/src/app/(list)/history/page.tsx
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { PokemonHistoryList } from "@/components/pokemon-history-list";
 import { getAllPokemon } from "@/lib/pokemon";
 import { Suspense } from "react";

--- a/src/app/(list)/page.tsx
+++ b/src/app/(list)/page.tsx
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { PokemonList } from "@/components/pokemon-list";
 import { getAllPokemon } from "@/lib/pokemon";
 import { Suspense } from "react";
@@ -6,7 +7,7 @@ export default async function PokemonPage() {
 	const pokemons = await getAllPokemon();
 
 	return (
-		<Suspense>
+		<Suspense fallback={<div>Loading...</div>}>
 			<PokemonList pokemons={pokemons} />
 		</Suspense>
 	);

--- a/src/app/(list)/page.tsx
+++ b/src/app/(list)/page.tsx
@@ -1,8 +1,13 @@
 import { PokemonList } from "@/components/pokemon-list";
 import { getAllPokemon } from "@/lib/pokemon";
+import { Suspense } from "react";
 
 export default async function PokemonPage() {
 	const pokemons = await getAllPokemon();
 
-	return <PokemonList pokemons={pokemons} />;
+	return (
+		<Suspense>
+			<PokemonList pokemons={pokemons} />
+		</Suspense>
+	);
 }


### PR DESCRIPTION
## Overview

This PR resolves build-time errors related to the use of `useSearchParams` and other client hooks by ensuring that all relevant client components are properly wrapped in `<Suspense>` and that dynamic rendering is enforced where necessary.

## Details

- Wrapped `PokemonList` and `PokemonHistoryList` components with `<Suspense>` in their respective pages.
- Added `export const dynamic = "force-dynamic";` to pages that use client hooks to ensure dynamic rendering and avoid SSG/ISR conflicts.
- Ensured that all client hooks are only used within client components.

## Motivation

- Fixes the Next.js build error:  
  `useSearchParams() should be wrapped in a suspense boundary at page ...`
- Ensures compatibility with Next.js App Router and client-side navigation patterns.
- Improves reliability and maintainability of the codebase.

## Related

- [Next.js Suspense and Client Components documentation](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)