### PR TITLE
🐛 fix: improve image loading UX with loading/error fallback in ImageCard

### DIFF
--- a/src/components/image-card.tsx
+++ b/src/components/image-card.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { createClient } from "@/lib/supabase/client";
+import { ImageIcon } from "lucide-react";
 import Image from "next/image";
+import { useState } from "react";
 
 export const ImageCard = ({ id }: { id: string }) => {
 	if (!id) return null;
@@ -11,14 +13,27 @@ export const ImageCard = ({ id }: { id: string }) => {
 		.from("sprites")
 		.getPublicUrl(`pokemons/normal/${id}.png`);
 
+	const [imgStatus, setImgStatus] = useState<"loading" | "error" | "loaded">(
+		"loading",
+	);
+
 	return (
 		<div className={"grid aspect-square place-items-center p-6"}>
 			<div className="relative h-full w-full">
+				{imgStatus !== "loaded" && (
+					<div className="absolute inset-0 flex items-center justify-center">
+						<ImageIcon className="size-8 text-muted-foreground" />
+					</div>
+				)}
 				<Image
 					src={data.publicUrl}
 					alt={`pokemon-${id}`}
 					className="object-contain"
 					fill
+					loading="lazy"
+					onLoad={() => setImgStatus("loaded")}
+					onError={() => setImgStatus("error")}
+					style={{ display: imgStatus === "error" ? "none" : undefined }}
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
## Overview

This PR improves the user experience for image loading in the `ImageCard` component.

## Details

- Shows a loading icon (`ImageIcon` from lucide-react) while the image is loading.
- Displays the same icon if the image fails to load (error fallback).
- Uses `next/image`'s `loading="lazy"` to optimize image loading performance.
- Ensures that broken or slow-loading images do not block the UI or cause layout shifts.

## Motivation

- Prevents blank or broken image states when Supabase Storage is slow or times out.
- Provides clear visual feedback to users during image loading and error states.
- Improves perceived performance and reliability of the Pokémon image grid.
