### PR TITLE
✨ feat: add shiny implementation history toggle to history and list pages

### DIFF
--- a/src/app/pokemon/[id]/page.tsx
+++ b/src/app/pokemon/[id]/page.tsx
@@ -21,8 +21,8 @@ export default async function PokemonDetail({ params }: Props) {
 					<h2 className="font-bold text-lg">{pokemon.name}</h2>
 				</div>
 				<div className="grid grid-cols-2 gap-2">
-					<ImageCard id={pokemon.id} />
-					<ImageCard id={pokemon.id} />
+					<ImageCard id={pokemon.id} isShiny={false} />
+					<ImageCard id={pokemon.id} isShiny />
 				</div>
 
 				{/* 基本ステータスカード */}

--- a/src/components/image-card.tsx
+++ b/src/components/image-card.tsx
@@ -5,13 +5,16 @@ import { ImageIcon } from "lucide-react";
 import Image from "next/image";
 import { useState } from "react";
 
-export const ImageCard = ({ id }: { id: string }) => {
+export const ImageCard = ({
+	id,
+	isShiny,
+}: { id: string; isShiny: boolean }) => {
 	if (!id) return null;
 
 	const supabase = createClient();
 	const { data } = supabase.storage
 		.from("sprites")
-		.getPublicUrl(`pokemons/normal/${id}.png`);
+		.getPublicUrl(`pokemons/${isShiny ? "shiny" : "normal"}/${id}.png`);
 
 	const [imgStatus, setImgStatus] = useState<"loading" | "error" | "loaded">(
 		"loading",

--- a/src/components/pokemon-card.tsx
+++ b/src/components/pokemon-card.tsx
@@ -10,7 +10,10 @@ import {
 } from "@ui/tooltip";
 import Link from "next/link";
 
-export const PokemonCard = ({ pokemon }: { pokemon: Pokemon }) => {
+export const PokemonCard = ({
+	isShiny,
+	pokemon,
+}: { isShiny: boolean; pokemon: Pokemon }) => {
 	if (!pokemon) {
 		return <div className="h-full w-full" />;
 	}
@@ -20,7 +23,7 @@ export const PokemonCard = ({ pokemon }: { pokemon: Pokemon }) => {
 			<Tooltip>
 				<TooltipTrigger>
 					<Link href={`pokemon/${pokemon.id}`}>
-						<ImageCard id={pokemon.id} />
+						<ImageCard id={pokemon.id} isShiny={isShiny} />
 					</Link>
 				</TooltipTrigger>
 				<TooltipContent>

--- a/src/components/pokemon-history-list.tsx
+++ b/src/components/pokemon-history-list.tsx
@@ -4,10 +4,14 @@ import { PokemonCard } from "@/components/pokemon-card";
 import { usePokemonParams } from "@/hooks/use-pokemon-params";
 import { processPokemons } from "@/lib/control-panel/process";
 import type { Pokemon } from "@/types/pokemon";
-import { useMemo } from "react";
+import { Button } from "@ui/button";
+import { useMemo, useState } from "react";
 
 export function PokemonHistoryList({ pokemons }: { pokemons: Pokemon[] }) {
 	const { options } = usePokemonParams();
+
+	// 通常/色違い切り替え
+	const [isShiny, setIsShiny] = useState(false);
 
 	const processedPokemon = useMemo(
 		() => processPokemons(pokemons, options),
@@ -17,7 +21,9 @@ export function PokemonHistoryList({ pokemons }: { pokemons: Pokemon[] }) {
 	// 実装日ごとにグループ化
 	const grouped: Record<string, typeof pokemons> = {};
 	for (const p of processedPokemon) {
-		const date = p.implemented_date || "未実装";
+		const date = isShiny
+			? p.shiny_implemented_date || "未実装"
+			: p.implemented_date || "未実装";
 		if (!grouped[date]) grouped[date] = [];
 		grouped[date].push(p);
 	}
@@ -37,6 +43,22 @@ export function PokemonHistoryList({ pokemons }: { pokemons: Pokemon[] }) {
 
 	return (
 		<div className="space-y-8">
+			<div className="flex items-center justify-between">
+				<h1 className="font-bold text-2xl">
+					{isShiny ? "ポケモン色違い実装履歴" : "ポケモン実装履歴"}
+				</h1>
+				<p className="text-muted-foreground">
+					{processedPokemon.length}匹のポケモンが見つかりました
+				</p>
+			</div>
+			<div className="mb-4 flex gap-2">
+				<Button disabled={!isShiny} onClick={() => setIsShiny(false)}>
+					通常実装履歴
+				</Button>
+				<Button disabled={isShiny} onClick={() => setIsShiny(true)}>
+					色違い実装履歴
+				</Button>
+			</div>
 			{sortedDates.map((date) => (
 				<section key={date}>
 					<h2 className="mb-2 font-bold text-base text-muted-foreground">
@@ -47,7 +69,11 @@ export function PokemonHistoryList({ pokemons }: { pokemons: Pokemon[] }) {
 							.slice()
 							.sort((a, b) => a.pokedex_number - b.pokedex_number)
 							.map((pokemon) => (
-								<PokemonCard key={pokemon.id} pokemon={pokemon} />
+								<PokemonCard
+									key={pokemon.id}
+									isShiny={isShiny}
+									pokemon={pokemon}
+								/>
 							))}
 					</div>
 				</section>

--- a/src/components/pokemon-list.tsx
+++ b/src/components/pokemon-list.tsx
@@ -4,10 +4,14 @@ import { PokemonCard } from "@/components/pokemon-card";
 import { usePokemonParams } from "@/hooks/use-pokemon-params";
 import { processPokemons } from "@/lib/control-panel/process";
 import type { Pokemon } from "@/types/pokemon";
-import { useMemo } from "react";
+import { Button } from "@ui/button";
+import { useMemo, useState } from "react";
 
 export function PokemonList({ pokemons }: { pokemons: Pokemon[] }) {
 	const { options } = usePokemonParams();
+
+	// 通常/色違い切り替え
+	const [isShiny, setIsShiny] = useState(false);
 
 	const processedPokemon = useMemo(
 		() => processPokemons(pokemons, options),
@@ -17,10 +21,20 @@ export function PokemonList({ pokemons }: { pokemons: Pokemon[] }) {
 	return (
 		<div className="space-y-4">
 			<div className="flex items-center justify-between">
-				<h1 className="font-bold text-2xl">ポケモン一覧</h1>
+				<h1 className="font-bold text-2xl">
+					{isShiny ? "色違いポケモン一覧" : "ポケモン一覧"}
+				</h1>
 				<p className="text-muted-foreground">
 					{processedPokemon.length}匹のポケモンが見つかりました
 				</p>
+			</div>
+			<div className="mb-4 flex gap-2">
+				<Button disabled={!isShiny} onClick={() => setIsShiny(false)}>
+					通常
+				</Button>
+				<Button disabled={isShiny} onClick={() => setIsShiny(true)}>
+					色違い
+				</Button>
 			</div>
 			{processedPokemon.length === 0 ? (
 				<div className="py-12 text-center">
@@ -31,7 +45,7 @@ export function PokemonList({ pokemons }: { pokemons: Pokemon[] }) {
 			) : (
 				<div className="grid-list">
 					{processedPokemon.map((pokemon) => (
-						<PokemonCard key={pokemon.id} pokemon={pokemon} />
+						<PokemonCard key={pokemon.id} isShiny={isShiny} pokemon={pokemon} />
 					))}
 				</div>
 			)}


### PR DESCRIPTION
## Overview
This PR adds a toggle feature to switch between normal and shiny implementation history on both the history and list pages.

## Details
- Adds toggle UI and logic in `PokemonHistoryList` to display either normal or shiny implementation history.
- Updates `PokemonCard` and `ImageCard` components to support the `isShiny` prop for correct image and tooltip display.
- Adds a shiny/normal toggle to the main Pokemon list page for consistent UX.
- Refactors related code for clarity and maintainability.

## Motivation
This feature allows users to easily view the implementation history of shiny Pokémon, improving the usability and completeness of the Pokédex history view.

## Notes
- No breaking changes.
- UI/UX is consistent with the rest of the app.
- Please review the toggle logic and isShiny prop propagation.